### PR TITLE
- fixed crash when notifying errors in Android

### DIFF
--- a/android/src/main/kotlin/com/greenbits/bugsnag_flutter/BugsnagFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/greenbits/bugsnag_flutter/BugsnagFlutterPlugin.kt
@@ -75,7 +75,7 @@ class BugsnagFlutterPlugin: FlutterPlugin, MethodCallHandler {
             for (frame in event.errors[0].stacktrace) {
               val index = event.errors[0].stacktrace.indexOf(frame)
 
-              if (stackSizeIndexed >= index) {
+              if (stackTrace.size - 1 >= index) {
                 val flutterFrame = stackTrace[index]
                 frame.file = flutterFrame["file"] as? String
                 frame.inProject = flutterFrame["inProject"] as? Boolean


### PR DESCRIPTION
Hey!,there is a blocker crash when notifying error in Android side. Please implement this PR ASAP.
